### PR TITLE
Fix to issue #4. English style suggestion.

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ permalink: index.html  # Is the only page that don't follow the partner /:path/i
 
 This lesson by the [Molecular Sciences Software Institute]({{ site.molssi_site }}) (MolSSI)
 teaches users [MolSSI's best practices](http://molssi.org/education/best-practices/)
-in Python module setup. To see the full MolSSI's education mission statement, please see
+in Python module setup. To see the full MolSSI's education mission statement, please click
 [here](http://molssi.org/education/education-mission-statement/).
 
 MolSSI best practices provides a starting point to get into software


### PR DESCRIPTION
The word "see" was repeated twice in the same sentence, therefore "see
[here]" was changed to "click [here]".