### PR TITLE
Addition of docstring testing with pytest

### DIFF
--- a/_episodes/02-github.md
+++ b/_episodes/02-github.md
@@ -49,7 +49,7 @@ Other hosting Services: [GitLab], [BitBucket]
 
 ## Making Commits
 
-Now that we have Git configured, let's try using Git do something that is actually helpful.
+Now that we have Git configured, let's try using Git to do something that is actually helpful.
 In this section, we are going to  edit files in the Python package that we created earlier, and use `git` to track those changes.
 
 First, use a terminal to `cd` into the top directory of the local repository.
@@ -57,8 +57,9 @@ First, use a terminal to `cd` into the top directory of the local repository.
 When we ran the CMS CookieCutter, it actually initialized the use of `git` for us, added our files, and made a commit (how convenient!). We can see this by typing
 
 ~~~
-ls -la
+$ ls -la
 ~~~
+{: .bash}
 
 Here, the `-la` says that we want to list the files in long format (`-l`), and show hidden files (`-a`). You should see several files starting with `.git`. In particular, `.git` is a directory where `git` stores the repository data. We can tell from this output that we are in a git repository.
 
@@ -221,6 +222,8 @@ Before we follow these directions, let's look at a few things in the repository.
 ~~~
 $ git remote -v
 ~~~
+{: .language-bash}
+
 
 You should see no output. Now, follow the instructions on GitHub under "...or push an existing repository from the command line"
 ~~~
@@ -470,7 +473,6 @@ $ ls -l
 While we're at it, also make some other files that aren't important to the project:
 
 ~~~
-$ mkdir data
 $ touch molssi_devops/data/calculation.in molssi_devops/data/calculation.out
 $ ls -l
 ~~~

--- a/_episodes/03-function-style.md
+++ b/_episodes/03-function-style.md
@@ -189,13 +189,14 @@ As a developer, you spend a lot of time thinking about writing your code. Howeve
  > You can read more about PEPs in [Python's documentation](https://www.python.org/dev/peps/pep-0001/). PEP1 outlines what a PEP is and how they work.
  {: .callout}
 
-If you look at PEP8, you will see that it is quite long. While you should definitely read it if you spend a lot of time programming in Python, there are luckily tools which will help us make sure our code is following PEP8 convention. We will you [yapf], an open source formatter for Python files from Google.
+If you look at PEP8, you will see that it is quite long. While you should definitely read it if you spend a lot of time programming in Python, there are luckily tools which will help us make sure our code is following PEP8 convention. We will use [yapf], an open source formatter for Python files from Google.
 
 Install yapf using pip. In your terminal, type
 
 ~~~
 $ pip install yapf
 ~~~
+{: .language-bash}
 
 Now we can use yapf on our python files. Just to see the power of yapf, let's mangle one of our functions and use yapf to reformat it.
 
@@ -232,6 +233,7 @@ If you save the file and test your function in the command line, you will see th
 ~~~
 $ yapf -i molssi_devops/molssi_math.py
 ~~~
+{: .language-bash}
 
 Here, the `-i` flag indicates to do this "in-place", this means your file will be overwritten with yapf's changes. If you examine the file after running yapf, you should see that it is returned to an easily readable format.
 

--- a/_episodes/04-collaboration.md
+++ b/_episodes/04-collaboration.md
@@ -37,7 +37,7 @@ In the next couple of sections, we will explore how this works in detail.
 
 ## Forks
 
-We have seen how it is possible to allow other people to contribute to a project by listing them as collaborators.  This works fine for a project that only a handful of people work on, but what about large open-source projects that might have hundreds of people who are interested in adding their own features?  No one wants to add of those names to the list of collaborators, and giving everyone who asks the ability to push anything they want to the repository is guaranteed to lead to problems.  The solution to this question comes in the form of “forks.”
+We have seen how it is possible to allow other people to contribute to a project by listing them as collaborators.  This works fine for a project that only a handful of people work on, but what about large open-source projects that might have hundreds of people who are interested in adding their own features?  No one wants to add all of those names to the list of collaborators, and giving everyone who asks the ability to push anything they want to the repository is guaranteed to lead to problems.  The solution to this question comes in the form of “forks.”
 
 Unfortunately, the word “fork” has multiple possible meanings in the context of open-source software development.
 Once upon a time, open-source software developers used the word “fork” to refer to the idea of taking an existing software project, making a copy of it, changing the name, and then developing it completely independently of the original project.
@@ -108,7 +108,7 @@ You will see the output
 ~~~
 Switched to a new branch 'title_case'
 ~~~
-{: .language-output}
+{: .output}
 
 Now, create a new file called "util.py" in the same folder as our first module (molssi_math). If you are in the top level of our repository, you can do
 
@@ -261,7 +261,7 @@ This time, you should see the following output
 ~~~
 'This Is A Test String.'
 ~~~
-{: .language-output}
+{: .output}
 
 Let's add and commit these changes (in two different commits)
 
@@ -284,7 +284,7 @@ remote: Create a pull request for 'title_case' on GitHub by visiting:
 remote:      https://github.com/YOUR_GITHUB_USERNAME/FORKED_REPO_NAME/pull/new/title_case
 remote:
 ~~~
-{: .language-output}
+{: .output}
 
 `git` is correct. What we will want to do next is create a pull request on the original repository to get our changes incorporated.
 
@@ -293,7 +293,7 @@ Have your partner check their repository - does the change appear for them?
 
 ## Pull requests
 
-It is now time to incorporate the edits you have made in you fork into the original repository.
+It is now time to incorporate the edits you have made in your fork into the original repository.
 To do this, we must create a `Pull Request`.
 
 Navigate to the URL of your fork. You should see a highlighted area and green button which says "Compare and Pull Request". Alternatively, you can navigate to the URL given in the message where you did a push.

--- a/_episodes/05-testing.md
+++ b/_episodes/05-testing.md
@@ -77,7 +77,7 @@ When we run `pytest`, it will look for directories and files which start with `t
 
 ~~~
 """
-Unit and regression test for the molssi_devops_2019 package.
+Unit and regression test for the molssi_devops package.
 """
 
 # Import package, test suite, and other packages as needed
@@ -157,7 +157,7 @@ Unit and regression test for the molssi_math module.
 """
 
 # Import package, test suite, and other packages as needed
-import molssi_devops_2019
+import molssi_devops
 import pytest
 import sys
 
@@ -255,7 +255,7 @@ Change the expected value back to 3 so that your tests pass.
 >> """
 >>
 >> # Import package, test suite, and other packages as needed
->> import molssi_devops_2019
+>> import molssi_devops
 >> import pytest
 >> import sys
 >>
@@ -531,31 +531,83 @@ and x=1/y=3 exhausting parameters in the order of the decorators.
 ### Testing Documentation Examples
 As our package changes over time, we want to make sure that the examples in our docstrings still behave as originally written, but checking these by hand can be a real pain.
 Luckily, `pytest` has a feature that will look for examples in docstrings and run them as tests.
-It will compare their output to the output in the docstring and check that they match.
 
-From the main `molssi_devops` directory, we can test the examples in the docstrings of `molssi_math.py`:
+`pytest` searches the docstrings for the Python shell code, which it executes and compares to the outputs in the docstring.
+For example, in the docstring of our function `title_case` we have:
 
 ~~~
-$ pytest -v --doctest-modules molssi_devops/molssi_math.py
+>>> title_case('ThIS is a STRinG to BE ConVerTeD.')
+'This Is A String To Be Converted.'
+~~~
+{: .language-python}
+
+`pytest` will find and execute `title_case('ThIS is a STRinG to BE ConVerTeD.')`.
+If the output is not `'This Is A String To Be Converted.'`, `pytest` will treat the test as a failure.
+
+From the main `molssi_devops` directory, we can test the examples in the docstrings of `util.py`:
+
+~~~
+$ pytest -v --doctest-modules molssi_devops/util.py
 ~~~
 {: .language-bash}
 
 ~~~
-================================================= test session starts =================================================
+================================================= test session starts ==================================================
 platform darwin -- Python 3.6.7, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- /Users/jets/miniconda3/envs/omp_mpi/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jets/Google Drive/research/MolSSI/CU_Boulder_Workshop/molssi_devops
 plugins: cov-2.6.1
-collected 1 item                                                                                                      
+collected 1 item                                                                                                       
 
-molssi_devops/molssi_math.py::molssi_devops.molssi_math.mean PASSED                                             [100%]
+molssi_devops/util.py::molssi_devops.util.title_case PASSED                                                      [100%]
 
-============================================== 1 passed in 0.06 seconds ===============================================
+=============================================== 1 passed in 0.10 seconds ===============================================
 ~~~
 {: .output}
 
-`pytest` also allows us to do this for multiple files at once by specify a directory or using wildcards (`*`).
-We can test the dosctring examples at the same time as our unit tests with:
+If we change the example in the `title_case` docstring to:
+
+~~~
+>>> title_case('ThIS is a STRinG to BE ConVerTeD.')
+'This Is A String To Be Converted'
+~~~
+{: .language-python}
+
+and re-run the test we get the following error:
+
+~~~
+================================================= test session starts ==================================================
+platform darwin -- Python 3.6.7, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- /Users/jets/miniconda3/envs/omp_mpi/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/jets/Google Drive/research/MolSSI/CU_Boulder_Workshop/molssi_devops
+plugins: cov-2.6.1
+collected 1 item                                                                                                       
+
+molssi_devops/util.py::molssi_devops.util.title_case FAILED                                                      [100%]
+
+======================================================= FAILURES =======================================================
+_______________________________________ [doctest] molssi_devops.util.title_case ________________________________________
+010     String to be converted to title case
+011
+012   Returns
+013   -------
+014   ret: str
+015     String converted to title case.
+016
+017   Example
+018   -------
+019   >>> title_case('ThIS is a STRinG to BE ConVerTeD.')
+Expected:
+    'This Is A String To Be Converted'
+Got:
+    'This Is A String To Be Converted.'
+
+/Users/jets/Google Drive/research/MolSSI/CU_Boulder_Workshop/molssi_devops/molssi_devops/util.py:19: DocTestFailure
+=============================================== 1 failed in 0.06 seconds ==============================================
+~~~
+{: .output}
+
+We can test multiple docstring examples at once and can even test the dosctring examples at the same time as our unit tests with:
 
 ~~~
 pytest -v --doctest-modules molssi_devops

--- a/_episodes/05-testing.md
+++ b/_episodes/05-testing.md
@@ -594,7 +594,7 @@ We'll measure this by counting the lines of our packages that are touched, i.e. 
 
 We already have everything we need for this since we installed `pytest-cov` earlier which includes the coverage tools on top of the `pytest` package.
 
-We can summarize our code coverage as follows:
+We can assess our code coverage as follows:
 
 ~~~
 pytest --cov=molssi_devops
@@ -626,16 +626,16 @@ TOTAL                             33      7    79%
 ~~~
 {: .output}
 
-For each file in the package, the output shows how many statements are in the file (i.e. not comments), how many weren't executed during testing, and the percentage of statements that were.
+The output shows how many statements (i.e. not comments) are in a file, how many weren't executed during testing, and the percentage of statements that were.
 For the example above, we have perfect coverage of `util.py`, but not `molssi_math.py`.
 
-We can see exactly which lines were touched in the `.coverage` file.
-For anything larger than our test package, this file becomes too convoluted to be human readable and we will need more tools to help us determine how to improve out tests.
-That will be the subject of Code Coverage pt. 2.
+To improve our coverage, we also want to see exactly which lines we missed and we can determine this using the `.coverage` file produced by `pytest`.
+Unfortunately, this strategy becomes impractical when we are working with anything larger than our test package because the `.coverage` file becomes too convoluted to read.
+We will need more tools to help us determine how to improve out tests and that will be the subject of Code Coverage pt. 2, which we will cover in Episode 6.
 
 > ## Do we need to get 100% coverage?
 >
-> Short answer: no.
+> Short answer: __no__.
 > Code coverage is a useful tool to assess how comprehensive our set of tests are and in general the higher our code coverage the better.
 > __However__, trying to achieve 100% coverage on packages any larger than this sample package is a bit unrealistic and would require more time than that last bit of coverage is worth.
 >

--- a/_episodes/05-testing.md
+++ b/_episodes/05-testing.md
@@ -9,8 +9,8 @@ objectives:
 - "Explain the reasons why testing is important."
 - "Understand how to write tests using the pytest framework."
 keypoints:
-- "Tests should cover individual functions/features and behaviour of the software as a whole."
-- "Write tests during development! It's harder to write tests after the package is complete."
+- "A good set of tests covers individual functions/features __and__ behavior of the software as a whole."
+- "It's better to write tests during development so you can check your progress along the way. The longer you wait to start the harder it is."
 - "Try to test as much of your package as you can, but don't go overboard, most packages don't have 100% test coverage."
 ---
 
@@ -530,9 +530,10 @@ and x=1/y=3 exhausting parameters in the order of the decorators.
 
 ### Testing Documentation Examples
 As our package changes over time, we want to make sure that the examples in our docstrings still behave as originally written, but checking these by hand can be a real pain.
-Luckily, `pytest` has a feature that will look for examples in docstrings and make sure their outputs still match what is shown in the docstring.
+Luckily, `pytest` has a feature that will look for examples in docstrings and run them as tests.
+It will compare their output to the output in the docstring and check that they match.
 
-From the main `molssi_devops` directory:
+From the main `molssi_devops` directory, we can test the examples in the docstrings of `molssi_math.py`:
 
 ~~~
 $ pytest -v --doctest-modules molssi_devops/molssi_math.py
@@ -553,7 +554,8 @@ molssi_devops/molssi_math.py::molssi_devops.molssi_math.mean PASSED             
 ~~~
 {: .output}
 
-We can test the dosctring examples at the same time as our unittests with:
+`pytest` also allows us to do this for multiple files at once by specify a directory or using wildcards (`*`).
+We can test the dosctring examples at the same time as our unit tests with:
 
 ~~~
 pytest -v --doctest-modules molssi_devops
@@ -624,15 +626,16 @@ TOTAL                             33      7    79%
 ~~~
 {: .output}
 
-For each file in the package the output shows how many statements are in the file (i.e. not comments), how many weren't executed during testing, and the percentage of statements that were.
+For each file in the package, the output shows how many statements are in the file (i.e. not comments), how many weren't executed during testing, and the percentage of statements that were.
 For the example above, we have perfect coverage of `util.py`, but not `molssi_math.py`.
 
 We can see exactly which lines were touched in the `.coverage` file.
-For anything larger than our test package this file becomes too convoluted to be human readable and we will need more tools to help us determine how to improve out tests.
+For anything larger than our test package, this file becomes too convoluted to be human readable and we will need more tools to help us determine how to improve out tests.
 That will be the subject of Code Coverage pt. 2.
 
 > ## Do we need to get 100% coverage?
 >
+> Short answer: no.
 > Code coverage is a useful tool to assess how comprehensive our set of tests are and in general the higher our code coverage the better.
 > __However__, trying to achieve 100% coverage on packages any larger than this sample package is a bit unrealistic and would require more time than that last bit of coverage is worth.
 >

--- a/_episodes/05-testing.md
+++ b/_episodes/05-testing.md
@@ -9,8 +9,9 @@ objectives:
 - "Explain the reasons why testing is important."
 - "Understand how to write tests using the pytest framework."
 keypoints:
-- "Enumerate the types of testing and the importance of each."
-- "Explain pytest features and why pytest was selected."
+- "Tests should cover individual functions/features and behaviour of the software as a whole."
+- "Write tests during development! It's harder to write tests after the package is complete."
+- "Try to test as much of your package as you can, but don't go overboard, most packages don't have 100% test coverage."
 ---
 
 Until now, we have been writing functions and checking their behavior using an interactive Python interpreter and manually inspecting the output. While this seems to work, it can be tedious, and prone to error. In this lesson, we'll discuss how to write tests and run them using the `pytest` testing framework.
@@ -66,7 +67,7 @@ make `pytest` particularly suited for computational chemistry.
 
 If you don't have `pytest` installed or it's not updated to version 3, install it using:
 ~~~
-$ pip install -U pytest
+$ pip install -U pytest-cov
 ~~~
 {: .bash}
 
@@ -445,6 +446,7 @@ def test_zero_length():
 
 You can run `pytest -m "not my_test"` to run all tests that are NOT marked with
 `@pytest.mark.my_test`.
+Custom marks are a great way to organize tests into groups so you can quickly run subsets of your tests while debugging your code.
 
 ## Edge and Corner Cases
 
@@ -525,3 +527,113 @@ def test_foo(x, y):
 
 This will run the test with the arguments set to x=0/y=2, x=1/y=2, x=0/y=3,
 and x=1/y=3 exhausting parameters in the order of the decorators.
+
+### Testing Documentation Examples
+As our package changes over time, we want to make sure that the examples in our docstrings still behave as originally written, but checking these by hand can be a real pain.
+Luckily, `pytest` has a feature that will look for examples in docstrings and make sure their outputs still match what is shown in the docstring.
+
+From the main `molssi_devops` directory:
+
+~~~
+$ pytest -v --doctest-modules molssi_devops/molssi_math.py
+~~~
+{: .language-bash}
+
+~~~
+================================================= test session starts =================================================
+platform darwin -- Python 3.6.7, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- /Users/jets/miniconda3/envs/omp_mpi/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/jets/Google Drive/research/MolSSI/CU_Boulder_Workshop/molssi_devops
+plugins: cov-2.6.1
+collected 1 item                                                                                                      
+
+molssi_devops/molssi_math.py::molssi_devops.molssi_math.mean PASSED                                             [100%]
+
+============================================== 1 passed in 0.06 seconds ===============================================
+~~~
+{: .output}
+
+We can test the dosctring examples at the same time as our unittests with:
+
+~~~
+pytest -v --doctest-modules molssi_devops
+~~~
+{: .language-bash}
+
+~~~
+================================================= test session starts =================================================
+platform darwin -- Python 3.6.7, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- /Users/jets/miniconda3/envs/omp_mpi/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/jets/Google Drive/research/MolSSI/CU_Boulder_Workshop/molssi_devops
+plugins: cov-2.6.1
+collected 12 items                                                                                                    
+
+molssi_devops/molssi_math.py::molssi_devops.molssi_math.mean PASSED                                             [  8%]
+molssi_devops/util.py::molssi_devops.util.title_case PASSED                                                     [ 16%]
+molssi_devops/tests/test_molssi_devops.py::test_molssi_devops_imported PASSED                                   [ 25%]
+molssi_devops/tests/test_molssi_math.py::test_many[num_list0-3] PASSED                                          [ 33%]
+molssi_devops/tests/test_molssi_math.py::test_many[num_list1-3] PASSED                                          [ 41%]
+molssi_devops/tests/test_molssi_math.py::test_many[num_list2-2.5] PASSED                                        [ 50%]
+molssi_devops/tests/test_molssi_math.py::test_many[num_list3-500000.0] PASSED                                   [ 58%]
+molssi_devops/tests/test_molssi_math.py::test_mean PASSED                                                       [ 66%]
+molssi_devops/tests/test_molssi_math.py::test_mean_type_error PASSED                                            [ 75%]
+molssi_devops/tests/test_molssi_math.py::test_zero_length PASSED                                                [ 83%]
+molssi_devops/tests/test_util.py::test_type_error PASSED                                                        [ 91%]
+molssi_devops/tests/test_util.py::test_title_case PASSED                                                        [100%]
+
+============================================== 12 passed in 0.25 seconds ==============================================
+~~~
+{: .output}
+
+### Code Coverage Pt. 1
+
+Now that we have a set of modules and associated tests, we want to see how much of our package is "covered" by our tests.
+We'll measure this by counting the lines of our packages that are touched, i.e. used, during our tests.
+
+We already have everything we need for this since we installed `pytest-cov` earlier which includes the coverage tools on top of the `pytest` package.
+
+We can summarize our code coverage as follows:
+
+~~~
+pytest --cov=molssi_devops
+~~~
+{: .language-bash}
+
+~~~
+================================================= test session starts =================================================
+platform darwin -- Python 3.6.7, pytest-4.4.1, py-1.8.0, pluggy-0.9.0
+rootdir: /Users/jets/Google Drive/research/MolSSI/CU_Boulder_Workshop/molssi_devops
+plugins: cov-2.6.1
+collected 10 items                                                                                                    
+
+molssi_devops/tests/test_molssi_devops.py .                                                                     [ 10%]
+molssi_devops/tests/test_molssi_math.py .......                                                                 [ 80%]
+molssi_devops/tests/test_util.py ..                                                                             [100%]
+
+---------- coverage: platform darwin, python 3.6.7-final-0 -----------
+Name                           Stmts   Miss  Cover
+--------------------------------------------------
+molssi_devops/__init__.py          7      0   100%
+molssi_devops/molssi_math.py      17      7    59%
+molssi_devops/util.py              9      0   100%
+--------------------------------------------------
+TOTAL                             33      7    79%
+
+
+============================================== 10 passed in 0.36 seconds ==============================================
+~~~
+{: .output}
+
+For each file in the package the output shows how many statements are in the file (i.e. not comments), how many weren't executed during testing, and the percentage of statements that were.
+For the example above, we have perfect coverage of `util.py`, but not `molssi_math.py`.
+
+We can see exactly which lines were touched in the `.coverage` file.
+For anything larger than our test package this file becomes too convoluted to be human readable and we will need more tools to help us determine how to improve out tests.
+That will be the subject of Code Coverage pt. 2.
+
+> ## Do we need to get 100% coverage?
+>
+> Code coverage is a useful tool to assess how comprehensive our set of tests are and in general the higher our code coverage the better.
+> __However__, trying to achieve 100% coverage on packages any larger than this sample package is a bit unrealistic and would require more time than that last bit of coverage is worth.
+>
+{: .callout}

--- a/_episodes/05-testing.md
+++ b/_episodes/05-testing.md
@@ -113,7 +113,7 @@ molssi_devops/tests/test_molssi_devops.py .                    [100%]
 
 =========================== 1 passed in 0.06 seconds ===========================
 ~~~
-{: .language-output}
+{: .output}
 
 Here, `pytest` has looked through our directory and its subdirectories for anything matching `test*`. It found the `tests` folder, and within that folder, it found the file `test_molssi_devops.py`. It then executed the function `test_molssi_devops_imported` within that module. Since our `assertion` was True, the test passed.
 
@@ -164,7 +164,7 @@ def test_mean():
     """Test that mean function calculates what we expect."""
     test_list = [1, 2, 3, 4, 5]
     expected = 3
-    calculated =  molssi_devops_2019.mean(test_list)
+    calculated =  molssi_devops.mean(test_list)
     assert expected == calculated
 ~~~
 {: .language-python}
@@ -176,6 +176,7 @@ Run this test using `pytest`. In the terminal window, type
 ~~~
 pytest -v
 ~~~
+{: .language-bash}
 
 You should now see the following.
 
@@ -191,7 +192,7 @@ molssi_devops/tests/test_molssi_math.py::test_mean PASSED           [100%]
 
 =========================== 2 passed in 0.07 seconds ===========================
 ~~~
-{: .language-output}
+{: .output}
 
 We now see that we have two tests which have been run, and they both passed.
 
@@ -222,14 +223,14 @@ __________________________________ test_mean ___________________________________
         """Test that mean function calculates what we expect."""
         test_list = [1, 2, 3, 4, 5]
         expected = 2
-        calculated =  molssi_devops_2019.mean(test_list)
+        calculated =  molssi_devops.mean(test_list)
 >       assert expected == calculated
 E       assert 2 == 3.0
 
 molssi_devops_2019/tests/test_molssi_math.py:19: AssertionError
 ====================== 1 failed, 1 passed in 0.17 seconds ======================
 ~~~
-{: .language-output}
+{: .output}
 
 Pytest shows a detailed failure report, including the source code around the failing line. The line that failed is marked with `>`.
 Next, it shows the values used in the assert comparison at runtime, that is `3.0 == 2`. This runtime analysis is one of the advantages of pytest that help you debug your code.
@@ -261,7 +262,7 @@ Change the expected value back to 3 so that your tests pass.
 >>     """Test the title case function."""
 >>     test_string = 'ThIS is a STRinG to BE ConVerTeD.'
 >>     expected = 'This Is A String To Be Converted.'
->>     calculated =  molssi_devops_2019.title_case(test_string)
+>>     calculated =  molssi_devops.title_case(test_string)
 >>     assert expected == calculated
 >> ~~~
 >> {: .language-python}
@@ -393,6 +394,7 @@ def test_zero_length():
     with pytest.raises(ValueError):
         molssi_devops.mean(test_list)
 ~~~
+{: .language-python}
 
 ### More Pytest Features - Pytest Marks
 
@@ -406,7 +408,7 @@ def test_mean_type_error():
     test_variable = 'this is a string'
 
     with pytest.raises(TypeError):
-        molssi_devops_2019.mean(test_variable)
+        molssi_devops.mean(test_variable)
 ~~~
 {: .python}
 
@@ -437,11 +439,11 @@ def test_zero_length():
     test_list = []
 
     with pytest.raises(ValueError):
-        molssi_devops_2019.mean(test_list)
+        molssi_devops.mean(test_list)
 ~~~
 {: .python}
 
-You can run `pytest -m 'not my_test` to run all tests that are NOT marked with
+You can run `pytest -m "not my_test"` to run all tests that are NOT marked with
 `@pytest.mark.my_test`.
 
 ## Edge and Corner Cases
@@ -497,7 +499,7 @@ import numpy as np
     ([1, 2, 3, 4, 5], 3),
     ([0, 2, 4, 6], 3),
     ([1, 2, 3, 4], 2.5),
-    (range(1, 1000000), 1000000/2.0)
+    (list(range(1, 1000000)), 1000000/2.0)
 ])
 
 def test_many(num_list, expected_mean):

--- a/_episodes/06-CI.md
+++ b/_episodes/06-CI.md
@@ -15,7 +15,7 @@ keypoints:
 
 A episode covering the basics of continuous integration.
 
-Continuous integration (CI) automatically runs builds your codes and run your tests on a variety of different platforms. Typically this may be run when new code is committed or before merging experimental code into the main repository. CI useful for catching bugs before they reach your end users, and for testing on platforms that are not available to every developer.
+Continuous integration (CI) automatically runs builds your codes and run your tests on a variety of different platforms. Typically this may be run when new code is committed or before merging experimental code into the main repository. CI is useful for catching bugs before they reach your end users, and for testing on platforms that are not available to every developer.
 
 Most CI software and services have webhooks for integration github.
 


### PR DESCRIPTION
I've added two small sections to Episode 5: 
1) testing examples in docstring with pytest and 
2) looking at code coverage with pytest. 

The code coverage section is meant as a preliminary introduction before it is discussed in more detail in the CI section along with codecov.io. The key points in episode 5 seemed more like objectives so I updated those as well. I also changed a few spelling mistakes.

You can view the version of the website for my fork [here](https://jamesetsmith.github.io/CMS-Python-DevOps/05-testing/index.html). Let me know what you think!
